### PR TITLE
Ensure console entrypoint sets up log handling

### DIFF
--- a/reaper
+++ b/reaper
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-# Wrapper for development to reaper entry point script
-
-exec python -m tf_reaper.reaper "$@"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.rst')) as f:
 
 setup(
     name='tf-reaper',
-    version='0.1.0',
+    version='0.1.1',
     license='MIT',
     author='Threshing Floor Security, LLC',
     author_email='info@threshingfloor.io',

--- a/tf_reaper/reaper_filter.py
+++ b/tf_reaper/reaper_filter.py
@@ -141,7 +141,7 @@ class ReaperFilter(object):
         noise_size = len(self.log_file.noisy_logs)
         quiet_size = len(self.log_file.quiet_logs)
 
-        stats_logger.info('{TOTAL_SIZE} lines were analyzed in this log file.'
+        stats_logger.info('{TOTAL_SIZE} lines were analyzed in this batch.'
                           .format(TOTAL_SIZE=total_size))
         stats_logger.info('{NOISE_SIZE} lines were determined to be noise by ThreshingFloor.'
                           .format(NOISE_SIZE=noise_size))
@@ -150,7 +150,7 @@ class ReaperFilter(object):
 
         if total_size:
             percent = "{0:0.01f}".format((int(quiet_size) / float(total_size)) * 100)
-            stats_logger.info("The input file was reduced to {PERCENT}% of its original size."
+            stats_logger.info("This batch was reduced to {PERCENT}% of its original size."
                               .format(PERCENT=percent))
 
     def _guess_type(self):

--- a/tf_reaper/tests/test_reaper_filter.py
+++ b/tf_reaper/tests/test_reaper_filter.py
@@ -150,10 +150,10 @@ class TestReaperFilter(TFTestCase):
             with mock.patch.object(stats_logger, 'info') as mock_stats_logger:
                 reaper.run()
                 self.assertEqual(mock_stats_logger.call_args_list,
-                                 [mock.call('3 lines were analyzed in this log file.'),
+                                 [mock.call('3 lines were analyzed in this batch.'),
                                   mock.call('1 lines were determined to be noise by ThreshingFloor.'),
                                   mock.call('2 lines were not determined to be noise by ThreshingFloor.'),
-                                  mock.call('The input file was reduced to 66.7% of its original size.')])
+                                  mock.call('This batch was reduced to 66.7% of its original size.')])
 
         # Should be no output since dry run
         self.assertEqual(open(filename).read(), "")


### PR DESCRIPTION
Version 0.1.0 introduced a regression where stats were not printed to stderr when using `--stats` or `--dry-run`.  This fixes it.