### PR TITLE
Use v2 api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.rst')) as f:
 
 setup(
     name='tf-reaper',
-    version='0.1.1',
+    version='0.1.2',
     license='MIT',
     author='Threshing Floor Security, LLC',
     author_email='info@threshingfloor.io',

--- a/tf_reaper/reaper_statistics_reporter.py
+++ b/tf_reaper/reaper_statistics_reporter.py
@@ -5,7 +5,7 @@ from .google_analytics import ga
 
 
 class ReaperStatisticsReporter(object):
-    api_endpoint = "/reducer/stats"
+    api_endpoint = "/v2/reducer/stats"
 
     def __init__(self, config):
         self.config = config

--- a/tf_reaper/tests/test_statistics_reporter.py
+++ b/tf_reaper/tests/test_statistics_reporter.py
@@ -36,7 +36,7 @@ class TestReaperStatisticsReporter(TFTestCase):
             mock_post.return_value = mock_response
             self.stats_reporter.report(self.log_file)
             self.assertTrue(mock_post.called)
-            expected_call = mock.call('http://localhost:8000/reducer/stats',
+            expected_call = mock.call('http://localhost:8000/v2/reducer/stats',
                                       headers={'x-api-key': '1111111111111111111111111111111111111111'},
                                       json={'lines_analyzed': 4,
                                             'API_KEY': '1111111111111111111111111111111111111111',


### PR DESCRIPTION
This moves to v2 api, which mainly adds json schema request validation.